### PR TITLE
Extract Scanning Workflow from Build & Push

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,38 @@
+name: Build and Push Image
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@4.0.0
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name == 'push'
+        uses: docker/login-action@3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@3.10.0
+
+      - name: Build and push
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        uses: docker/build-push-action@6.18.0
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'platform-engineering-org/afula' }}
+          tags: ghcr.io/${{ github.repository_owner }}/afula:latest
+          platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/build-and-scan.yml
+++ b/.github/workflows/build-and-scan.yml
@@ -1,13 +1,7 @@
-name: Build and Push Docker Image to GCR
+name: Build and Scan Image
 
 on:
   pull_request_target:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
 
 jobs:
   build:
@@ -20,24 +14,8 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@3.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@3.11.1
-
-      - name: Build and push
-        if: github.event_name == 'pull_request' || github.event_name == 'push'
-        uses: docker/build-push-action@6.18.0
-        with:
-          context: .
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'platform-engineering-org/afula' }}
-          tags: ghcr.io/${{ github.repository_owner }}/afula:latest
-          platforms: linux/amd64,linux/arm64/v8
 
       - name: Build for scanning
         if: github.event_name == 'pull_request_target'
@@ -50,7 +28,6 @@ jobs:
           platforms: linux/amd64
 
       - name: Scan image for vulnerabilities
-        if: github.event_name == 'pull_request_target'
         uses: aquasecurity/trivy-action@0.31.0
         with:
           image-ref: afula:pr-${{ github.event.pull_request.number }}
@@ -61,7 +38,6 @@ jobs:
           severity: CRITICAL,HIGH
 
       - name: Read scan results into output
-        if: github.event_name == 'pull_request_target'
         id: read-scan
         run: |
           echo "scan_output<<EOF" >> $GITHUB_OUTPUT
@@ -69,7 +45,6 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Get comment ID
-        if: github.event_name == 'pull_request_target'
         id: get-comment
         uses: peter-evans/find-comment@v3.1.0
         with:
@@ -78,7 +53,6 @@ jobs:
           body-includes: '### 🔒 Trivy Scan Results for `afula:pr-${{ github.event.pull_request.number }}`'
 
       - name: Post Trivy scan result as PR comment
-        if: github.event_name == 'pull_request_target'
         uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
This PR separates the security scanning logic from the build-and-push workflow. The new structure allows for independent execution of image scanning, improving modularity, clarity, and maintainability of the CI pipeline.

✅ Benefits
Decouples scanning from image publishing

Enables more targeted pipeline runs and future reuse

Improves debugging and testing of scanning logic