### PR TITLE
db module

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -15,21 +15,21 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@4.2.2
+        uses: actions/checkout@v4.2.2
 
       - name: Login to GitHub Container Registry
         if: github.event_name == 'push'
-        uses: docker/login-action@3.4.0
+        uses: docker/login-action@v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@3.11.1
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Build and push
-        uses: docker/build-push-action@6.18.0
+        uses: docker/build-push-action@v6.18.0
         with:
           context: .
           file: manager/Dockerfile

--- a/.github/workflows/build-and-scan.yml
+++ b/.github/workflows/build-and-scan.yml
@@ -10,15 +10,15 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@4.2.2
+        uses: actions/checkout@v4.2.2
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@3.11.1
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Build for scanning
-        uses: docker/build-push-action@6.18.0
+        uses: docker/build-push-action@v6.18.0
         with:
           context: .
           file: manager/Dockerfile
@@ -28,7 +28,7 @@ jobs:
           platforms: linux/amd64
 
       - name: Scan image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.32.0
+        uses: aquasecurity/trivy-action@v0.32.0
         with:
           image-ref: afula-manager:pr-${{ github.event.pull_request.number }}
           format: table

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@4.2.2
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@5.6.0
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: '3.13'
 
@@ -28,4 +28,4 @@ jobs:
         run: pre-commit run --all-files
 
       - name: Run unit tests with pytest
-        run: python -m pytest
+        run: python -m pytest --import-mode=importlib

--- a/.github/workflows/deploy-kind.yml
+++ b/.github/workflows/deploy-kind.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@4.2.2
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@3.11.1
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Build
-        uses: docker/build-push-action@6.18.0
+        uses: docker/build-push-action@v6.18.0
         with:
           context: .
           file: manager/Dockerfile

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,3 @@
+"""Initialize the package and mark the directory as a Python package."""
+
+from . import config

--- a/db/config.py
+++ b/db/config.py
@@ -1,0 +1,31 @@
+"""
+Shared PostgreSQL configuration helper for multiple microservices.
+
+This module provides a single source of truth for constructing the
+PostgreSQL connection URI using environment variables. Both microservices
+in the monorepo can import and reuse this helper to ensure consistent
+database connectivity without duplicating configuration logic.
+
+Environment Variables:
+- POSTGRES_HOST: hostname of the PostgreSQL server (default: "localhost")
+- POSTGRES_DB: database name (default: "mydb")
+- POSTGRES_USER: database username (default: "user")
+- POSTGRES_PASSWORD: database password (default: "password")
+
+Example:
+    from db.config import get_postgres_uri
+
+    DATABASE_URI = get_postgres_uri()
+
+"""
+
+import os
+
+
+def get_postgres_uri() -> str:
+    """Return PostgreSQL URI from environment variables (single source of truth)."""
+    host = os.environ.get("POSTGRES_HOST", "localhost")
+    db = os.environ.get("POSTGRES_DB", "mydb")
+    user = os.environ.get("POSTGRES_USER", "user")
+    password = os.environ.get("POSTGRES_PASSWORD", "password")
+    return f"postgresql://{user}:{password}@{host}/{db}"

--- a/db/tests/unit/test_config.py
+++ b/db/tests/unit/test_config.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for the shared PostgreSQL configuration helper.
+
+This test suite verifies the behavior of `get_postgres_uri` in `db.config`.
+It ensures that:
+
+- Default environment variable values are used when none are set.
+- Custom environment variable values are correctly reflected in the URI.
+
+Uses pytest's `monkeypatch` fixture to temporarily modify environment variables
+during tests.
+"""
+
+from db import config
+
+
+def test_get_postgres_uri_defaults(monkeypatch):
+    """Test that defaults are used when no environment variables are set."""
+    # Clear environment variables for the test
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+    monkeypatch.delenv("POSTGRES_DB", raising=False)
+    monkeypatch.delenv("POSTGRES_USER", raising=False)
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+
+    uri = config.get_postgres_uri()
+    assert uri == "postgresql://user:password@localhost/mydb"
+
+
+def test_get_postgres_uri_custom(monkeypatch):
+    """Test that custom environment variables are correctly used."""
+    monkeypatch.setenv("POSTGRES_HOST", "db-server")
+    monkeypatch.setenv("POSTGRES_DB", "testdb")
+    monkeypatch.setenv("POSTGRES_USER", "admin")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "secret")
+
+    uri = config.get_postgres_uri()
+    assert uri == "postgresql://admin:secret@db-server/testdb"

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -5,6 +5,7 @@ ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
+COPY db/ ./db/
 COPY manager/ ./manager/
 
 RUN pip install -r manager/requirements.txt

--- a/manager/config.py
+++ b/manager/config.py
@@ -8,12 +8,7 @@ and other Flask extensions. Values can be overridden via environment variables.
 Author: Liora Milbaum
 """
 
-import os
-
-DB_HOST = os.environ.get("POSTGRES_HOST")
-DB_NAME = os.environ.get("POSTGRES_DB")
-DB_USER = os.environ.get("POSTGRES_USER")
-DB_PASS = os.environ.get("POSTGRES_PASSWORD")
+from db import config
 
 
 class Config:
@@ -21,15 +16,20 @@ class Config:
     Base configuration class for the Flask application.
 
     Provides default settings including:
-    - Database URI (from the DATABASE_URL environment variable or a default fallback)
+    - Database URI (from centralized helper)
     - SQLAlchemy behavior
     - Secret key for session management
-
-    Intended to be extended for environment-specific configurations (e.g., testing, production).
     """
 
     WTF_CSRF_ENABLED = False
-    SQLALCHEMY_DATABASE_URI = (
-        f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:5432/{DB_NAME}"
-    )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+    def __init__(self):
+        """
+        Initialize the configuration instance.
+
+        Reads the PostgreSQL connection URI from environment variables via
+        the shared `get_postgres_uri()` helper. This allows tests to
+        monkeypatch environment variables before instantiation.
+        """
+        self.SQLALCHEMY_DATABASE_URI = config.get_postgres_uri()

--- a/manager/database.py
+++ b/manager/database.py
@@ -6,27 +6,9 @@ This module initializes the global `db` instance using Flask‑SQLAlchemy.
 Author: Liora Milbaum
 """
 
-import os
-
 import flask_sqlalchemy
 
 db = flask_sqlalchemy.SQLAlchemy()
-
-
-def get_db_uri():
-    """
-    Build the SQLAlchemy database URI from environment variables.
-
-    Returns:
-        str: A PostgreSQL connection URI in the format
-        'postgresql://<user>:<password>@<host>:5432/<database>'.
-
-    """
-    DB_HOST = os.environ.get("POSTGRES_HOST", "localhost")
-    DB_NAME = os.environ.get("POSTGRES_DB", "mydb")
-    DB_USER = os.environ.get("POSTGRES_USER", "user")
-    DB_PASS = os.environ.get("POSTGRES_PASSWORD", "password")
-    return f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:5432/{DB_NAME}"
 
 
 def init_db(app):

--- a/manager/main.py
+++ b/manager/main.py
@@ -27,7 +27,7 @@ def create_app(test_config=None):
     app = flask.Flask(__name__)
 
     if test_config is None:
-        app.config.from_object(config.Config)
+        app.config.from_object(config.Config())
     else:
         app.config.from_object(test_config)
 

--- a/manager/tests/unit/test_config.py
+++ b/manager/tests/unit/test_config.py
@@ -1,39 +1,70 @@
 """
-Unit tests for the config module.
+Unit tests for the application configuration module.
 
-Tests:
-- Environment variables are read correctly.
-- Config.SQLALCHEMY_DATABASE_URI is built as expected.
+Tests Config class and get_postgres_uri helper for correct environment variable handling.
 
 Author: Liora Milbaum
 """
 
-import os
+from db import config as db_config
+from manager import config as manager_config
 
-from manager import config
-
-
-def test_sqlalchemy_database_uri(monkeypatch):
-    """Test that Config.SQLALCHEMY_DATABASE_URI builds the expected URI."""
-    monkeypatch.setenv("POSTGRES_HOST", "dbhost")
-    monkeypatch.setenv("POSTGRES_DB", "mydb")
-    monkeypatch.setenv("POSTGRES_USER", "myuser")
-    monkeypatch.setenv("POSTGRES_PASSWORD", "mypass")
-
-    # Reload module to pick up monkeypatched env vars
-    import importlib
-
-    importlib.reload(config)
-
-    expected_uri = "postgresql://myuser:mypass@dbhost:5432/mydb"
-    assert config.Config.SQLALCHEMY_DATABASE_URI == expected_uri
+# -------------------- get_postgres_uri Tests -------------------- #
 
 
-def test_csrf_disabled():
-    """Test that WTF_CSRF_ENABLED is False by default."""
-    assert config.Config.WTF_CSRF_ENABLED is False
+def test_get_postgres_uri_defaults(monkeypatch):
+    """Verify that get_postgres_uri() returns default values when no environment variables are set."""
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+    monkeypatch.delenv("POSTGRES_DB", raising=False)
+    monkeypatch.delenv("POSTGRES_USER", raising=False)
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+
+    uri = db_config.get_postgres_uri()
+    expected_uri = "postgresql://user:password@localhost/mydb"
+    assert uri == expected_uri
 
 
-def test_sqlalchemy_track_modifications_disabled():
-    """Test that SQLAlchemy track modifications is False by default."""
-    assert config.Config.SQLALCHEMY_TRACK_MODIFICATIONS is False
+def test_get_postgres_uri_custom(monkeypatch):
+    """Verify that get_postgres_uri() correctly reflects custom environment variables."""
+    monkeypatch.setenv("POSTGRES_HOST", "db-server")
+    monkeypatch.setenv("POSTGRES_DB", "testdb")
+    monkeypatch.setenv("POSTGRES_USER", "admin")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "secret")
+
+    uri = db_config.get_postgres_uri()
+    expected_uri = "postgresql://admin:secret@db-server/testdb"
+    assert uri == expected_uri
+
+
+# -------------------- Config Class Tests -------------------- #
+
+
+def test_config_db_uri_defaults(monkeypatch):
+    """Verify Config.SQLALCHEMY_DATABASE_URI uses default values when no env vars are set."""
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+    monkeypatch.delenv("POSTGRES_DB", raising=False)
+    monkeypatch.delenv("POSTGRES_USER", raising=False)
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+
+    cfg = manager_config.Config()
+    expected_uri = "postgresql://user:password@localhost/mydb"
+    assert cfg.SQLALCHEMY_DATABASE_URI == expected_uri
+
+
+def test_config_db_uri_custom(monkeypatch):
+    """Verify Config.SQLALCHEMY_DATABASE_URI correctly reflects custom PostgreSQL environment variables."""
+    monkeypatch.setenv("POSTGRES_HOST", "db-server")
+    monkeypatch.setenv("POSTGRES_DB", "testdb")
+    monkeypatch.setenv("POSTGRES_USER", "admin")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "secret")
+
+    cfg = manager_config.Config()
+    expected_uri = "postgresql://admin:secret@db-server/testdb"
+    assert cfg.SQLALCHEMY_DATABASE_URI == expected_uri
+
+
+def test_config_defaults():
+    """Verify other default Config settings."""
+    cfg = manager_config.Config()
+    assert cfg.WTF_CSRF_ENABLED is False
+    assert cfg.SQLALCHEMY_TRACK_MODIFICATIONS is False

--- a/manager/tests/unit/test_main.py
+++ b/manager/tests/unit/test_main.py
@@ -2,14 +2,60 @@
 Unit tests for the Flask application factory and /register endpoint.
 
 This module tests:
-- The creation and configuration of the Flask app via create_app().
-- That the /register route is properly registered.
-- That posting valid data to /register inserts a Repo into the database.
-- That invalid payloads return appropriate error responses.
+- App creates with default config.
+- App uses provided test config.
+- Routes register correctly.
+
+Author: Liora Milbaum
 """
 
-import sqlalchemy
-from manager import database
+from unittest import mock
+
+from manager import main
+
+
+def test_create_app_default():
+    """App should load default config if test_config not provided."""
+    with (
+        mock.patch("manager.database.db.init_app") as mock_init,
+        mock.patch("manager.database.db.create_all") as mock_create_all,
+    ):
+        app = main.create_app()
+
+        mock_init.assert_called_once_with(app)
+        mock_create_all.assert_called_once()
+
+        assert "SQLALCHEMY_DATABASE_URI" in app.config
+
+
+def test_create_app_with_test_config():
+    """App should use given test_config."""
+    with (
+        mock.patch("manager.database.db.init_app") as mock_init,
+        mock.patch("manager.database.db.create_all") as mock_create_all,
+    ):
+
+        class TestConfig:
+            """Configuration for tests. Uses in-memory SQLite and disables tracking."""
+
+            SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+            SQLALCHEMY_TRACK_MODIFICATIONS = False
+            TESTING = True
+
+        app = main.create_app(test_config=TestConfig)
+
+        mock_init.assert_called_once_with(app)
+        mock_create_all.assert_called_once()
+
+        assert app.config["TESTING"] is True
+        assert app.config["SQLALCHEMY_DATABASE_URI"] == "sqlite:///:memory:"
+
+
+def test_home_route(client):
+    """GET / should return welcome JSON."""
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json["message"] == "Welcome to the Afula app!"
 
 
 def test_register_endpoint_exists(app):
@@ -21,7 +67,7 @@ def test_register_endpoint_exists(app):
 def test_register_repo_success(client, app):
     """POST /repos/register should insert a new Repo record into the DB."""
     with app.app_context():
-        database.db.create_all()
+        main.database.db.create_all()
 
     payload = {"name": "test-repo", "url": "https://github.com/afula/test-repo"}
     response = client.post("/repos/register", json=payload)
@@ -30,7 +76,7 @@ def test_register_repo_success(client, app):
 
 
 def test_register_repo_bad_payload(client):
-    """POST /register with missing fields should return 400."""
+    """POST /repos/register with missing fields should return 400."""
     response = client.post("/repos/register", json={})
     assert response.status_code == 400
     data = response.get_json()

--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -2,6 +2,7 @@ FROM registry.access.redhat.com/ubi10/python-312-minimal:10.0-1747316123
 
 WORKDIR /app
 
+COPY db/ ./db/
 COPY processor/ ./processor/
 
 RUN pip install -r processor/requirements.txt

--- a/processor/database.py
+++ b/processor/database.py
@@ -5,18 +5,10 @@ Exports:
     - get_all_items():       Returns IDs of all items in the table.
 """
 
-import os
-
 import sqlalchemy
+from db.config import get_postgres_uri
 
-DB_HOST = os.environ.get("POSTGRES_HOST")
-DB_NAME = os.environ.get("POSTGRES_DB")
-DB_USER = os.environ.get("POSTGRES_USER")
-DB_PASS = os.environ.get("POSTGRES_PASSWORD")
-
-engine = sqlalchemy.create_engine(
-    f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:5432/{DB_NAME}"
-)
+engine = sqlalchemy.create_engine(get_postgres_uri())
 
 
 def get_all_items():


### PR DESCRIPTION
This PR centralizes database configuration by defining the SQLAlchemy database URI in a single place (config.Config).

Why

- Avoids duplication of DB connection strings across the codebase.
- Makes it easier to manage environment-based overrides (POSTGRES_HOST, POSTGRES_DB, etc.).
- Improves maintainability and reduces risk of inconsistencies.

⚠️ Note on CI
The build-and-scan workflow is currently failing because it depends on these configuration changes, which are not yet present in main. Once this PR is merged, the workflow should pass.